### PR TITLE
Connection error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const sendRequest = async (method, methodArgs, program) => {
   try {
     await electrum.connect()
   } catch (error) {
-    abort(`Could not connect to ${server} due to ${error}`)
+    abort(`Could not connect to ${server}\nReason: ${error.message}`)
   }
 
   const response = await electrum.request(method, ...methodArgs)

--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ const sendRequest = async (method, methodArgs, program) => {
 
   const electrum = new ElectrumClient('electrum-cli', opts.version, host, port)
 
-  const connectionStatus = await electrum.connect()
-
-  ensure(connectionStatus, `Could not connect to ${server}`)
+  await electrum.connect().catch(() => {
+    abort(`Could not connect to ${server}`)
+  })
 
   const response = await electrum.request(method, ...methodArgs)
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
 const { program } = require('commander')
 const { ElectrumClient } = require('electrum-cash')
-const { ensure, parseValue } = require('./util')
+const { ensure, abort, parseValue } = require('./util')
 
 const sendRequest = async (method, methodArgs, program) => {
   const opts = program.opts()
@@ -19,9 +19,11 @@ const sendRequest = async (method, methodArgs, program) => {
 
   const electrum = new ElectrumClient('electrum-cli', opts.version, host, port)
 
-  await electrum.connect().catch(() => {
-    abort(`Could not connect to ${server}`)
-  })
+  try {
+    await electrum.connect()
+  } catch (error) {
+    abort(`Could not connect to ${server} due to ${error}`)
+  }
 
   const response = await electrum.request(method, ...methodArgs)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "commander": "^6.2.0",
-    "electrum-cash": "^2.0.5"
+    "electrum-cash": "^2.0.6"
   },
   "devDependencies": {
     "eslint": "^7.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,10 +276,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-electrum-cash@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/electrum-cash/-/electrum-cash-2.0.5.tgz#e402bd767d0593611106e030bfd4ec92d5c8fe9c"
-  integrity sha512-3EoeJMgo2rHXvQqjdzwAemXWdFCO6ssmuaY2b9/AdVh4j7GFiJkgzLFptnjtjgWDZyaiP/miEuFYIbIq7ladGQ==
+electrum-cash@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/electrum-cash/-/electrum-cash-2.0.6.tgz#005aa46ddace872696a89d918640ff6254a1ddaa"
+  integrity sha512-+o0Hqcl0eCwd9fvCJpWn4yV3gYX874uCGpwpwNbZuEU9ipY5ft9iU0IfuFghUN6/AuCcsE6f8JkVOjuTjmfF5Q==
   dependencies:
     "@types/ws" "^7.2.6"
     async-mutex "^0.2.4"


### PR DESCRIPTION
This is allows `electrum-cli` to depend on `electrum-cash >= 2.0.6`.

Fixes #1 but I don't think it addresses the underlying cause which I don't understand but has something to do with dependency management. On my system when I installed `electrum-cli` globally with yarn it installed the dependency 'electrum-cash@2.0.6' which breaks `elctrum-cli`. The `yarn.lock` file specifies 'electrum-cash@2.0.5'. 

